### PR TITLE
Configure OkHttp3 to use proxy credentials

### DIFF
--- a/language-server/src/main/java/org/sonarlint/languageserver/SonarLintLanguageServer.java
+++ b/language-server/src/main/java/org/sonarlint/languageserver/SonarLintLanguageServer.java
@@ -334,6 +334,7 @@ public class SonarLintLanguageServer implements LanguageServer, WorkspaceService
       .token(serverInfo.token)
       .organizationKey(serverInfo.organizationKey)
       .userAgent(USER_AGENT)
+      .proxyCredentials(System.getProperty("http.proxyUser"), System.getProperty("http.proxyPassword"))
       .build();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <protobuf.version>3.6.1</protobuf.version>
     <protobuf.compiler>${settings.localRepository}/com/google/protobuf/protoc/${protobuf.version}/protoc-${protobuf.version}-${os.detected.classifier}.exe</protobuf.compiler>
     <gitRepositoryName>sonarlint-core</gitRepositoryName>
-    <okhttp.version>3.11.0</okhttp.version>
+    <okhttp.version>4.9.0</okhttp.version>
     <!-- Release: enable publication to Bintray -->
     <artifactsToPublish>${project.groupId}:sonarlint-daemon:zip:windows,${project.groupId}:sonarlint-language-server:jar</artifactsToPublish>
     <jarsigner.skip>true</jarsigner.skip>


### PR DESCRIPTION
The `http.proxyUser` and `http.proxyPassword` creds are not used in the sonarlint language server.

It looks like these two params are not used in low-level JVM network proxying implementation. E.g. they are not listed in the JVM proxying parameters:
https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html

These two parameters should be used on higher level HTTP client providers. The OkHttp3 client handles proxy authentication errors and may send corresponding credentials if they're configured.

I have updated sonarlint-language-server a little, so it will pass `http.proxyUser` and `http.proxyPassword` system properties into OkHttp3 client. And the rest stuff the okhttp client will do out of the box.

I've tested the fix on my dev machine with Squid proxy server with enabled Basic Authentication.