### PR TITLE
Added Codescan customization on sonarlint-core library

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ stages:
     burgrName: 'validate'
     burgrType: 'validate'
     stageName: 'validate'
-    stageDisplayName: Run UTs and trigger SonarQube analysis
+    stageDisplayName: Run UTs and trigger CodeScan analysis
     jobs:
     - job: test_windows
       displayName: Run unit tests on Windows
@@ -181,7 +181,7 @@ stages:
           jdkVersionOption: '1.11'
           mavenOptions: $(MAVEN_OPTS)
     - job: sonarqube
-      displayName: SonarQube analysis on Next
+      displayName: CodeScan analysis on Next
       variables:
         MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
         MAVEN_OPTS: '-Xmx3072m -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.sonarlint.core</groupId>
     <artifactId>sonarlint-core-parent</artifactId>
-    <version>7.0-SNAPSHOT</version>
+    <version>7.0.0-CODESCAN</version>
   </parent>
   <artifactId>sonarlint-core</artifactId>
   <packaging>bundle</packaging>
@@ -221,78 +221,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-slf4j-sonar-log</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>${project.groupId}</groupId>
-                  <artifactId>sonarlint-slf4j-sonar-log</artifactId>
-                  <version>${project.version}</version>
-                  <type>jar</type>
-                </artifactItem>
-              </artifactItems>
-              <outputDirectory>${project.build.outputDirectory}/</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>true</overWriteSnapshots>
-              <stripVersion>true</stripVersion>
-            </configuration>
-          </execution>
-          <execution>
-            <id>copy-sonar-plugins</id>
-            <phase>generate-test-resources</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.sonarsource.java</groupId>
-                  <artifactId>sonar-java-plugin</artifactId>
-                  <version>6.0.0.20538</version>
-                  <type>jar</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.sonarsource.sonarqube</groupId>
-                  <artifactId>sonar-xoo-plugin</artifactId>
-                  <version>${sonarqube.version}</version>
-                  <type>jar</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.sonarsource.javascript</groupId>
-                  <artifactId>sonar-javascript-plugin</artifactId>
-                  <version>6.5.0.13383</version>
-                  <type>jar</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.sonarsource.php</groupId>
-                  <artifactId>sonar-php-plugin</artifactId>
-                  <version>3.2.0.4868</version>
-                  <type>jar</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.sonarsource.python</groupId>
-                  <artifactId>sonar-python-plugin</artifactId>
-                  <version>1.14.0.3086</version>
-                  <type>jar</type>
-                </artifactItem>
-              </artifactItems>
-              <outputDirectory>${project.build.directory}/plugins</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>true</overWriteSnapshots>
-              <stripVersion>false</stripVersion>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
@@ -468,46 +396,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>commercial</id>
-      <activation>
-        <property>
-          <name>commercial</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-commercial-plugins</id>
-                <phase>validate</phase>
-                <goals>
-                  <goal>copy</goal>
-                </goals>
-                <configuration>
-                  <artifactItems>
-                    <artifactItem>
-                      <groupId>com.sonarsource.cpp</groupId>
-                      <artifactId>sonar-cfamily-plugin</artifactId>
-                      <version>6.18.0.29274</version>
-                      <type>jar</type>
-                    </artifactItem>
-                  </artifactItems>
-                  <outputDirectory>${project.build.directory}/plugins</outputDirectory>
-                  <overWriteReleases>false</overWriteReleases>
-                  <overWriteSnapshots>true</overWriteSnapshots>
-                  <stripVersion>false</stripVersion>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/core/src/main/java/org/sonarsource/sonarlint/core/client/api/common/Language.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/client/api/common/Language.java
@@ -49,11 +49,13 @@ public enum Language {
   RUBY("ruby", "ruby", "Ruby", new String[] {".rb"}, "sonar.ruby.file.suffixes"),
   SCALA("scala", "sonarscala", "Scala", new String[] {".scala"}, "sonar.scala.file.suffixes"),
   SECRETS("secrets", "secrets", "Secrets", new String[0], "sonar.secrets.file.suffixes"),
+  SF("sf", "sf", "SF", new String[] {".cls", ".trigger"}, "sonar.sf.file.suffixes"),
   SWIFT("swift", "swift", "Swift", new String[] {".swift"}, "sonar.swift.file.suffixes"),
   TSQL("tsql", "tsql", "T-SQL", new String[] {".tsql"}, "sonar.tsql.file.suffixes"),
   TS("ts", "javascript", "TypeScript", new String[] {".ts", ".tsx"},
     "sonar.typescript.file.suffixes"),
   JSP("jsp", "web", "JSP", new String[] {".jsp", ".jspf", ".jspx"}, "sonar.jsp.file.suffixes"),
+  VF("vf", "vf", "VF", new String[] {".page", ".component", ".app", ".evt", ".cmp", ".intf"}, "sonar.vf.file.suffixes"),
   XML("xml", "xml", "XML", new String[] {".xml", ".xsd", ".xsl"}, "sonar.xml.file.suffixes"),
   // For ITs
   XOO("xoo", "xoo", "Xoo", new String[] {".xoo"}, "sonar.xoo.file.suffixes");

--- a/core/src/main/java/org/sonarsource/sonarlint/core/client/api/connected/ProjectBinding.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/client/api/connected/ProjectBinding.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Describes the link between a project in the IDE and a project in SonarQube.
+ * Describes the link between a project in the IDE and a project in CodeScan.
  *
  * @since 3.10
  */

--- a/core/src/main/java/org/sonarsource/sonarlint/core/client/api/exceptions/ProjectNotFoundException.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/client/api/exceptions/ProjectNotFoundException.java
@@ -29,8 +29,8 @@ public class ProjectNotFoundException extends SonarLintException {
 
   private static String formatMessage(String moduleKey, @Nullable String organizationKey) {
     if (organizationKey != null) {
-      return String.format("Project with key '%s' in organization '%s' not found on SonarQube server (was it deleted?)", moduleKey, organizationKey);
+      return String.format("Project with key '%s' in organization '%s' not found on CodeScan server (was it deleted?)", moduleKey, organizationKey);
     }
-    return String.format("Project with key '%s' not found on SonarQube server (was it deleted?)", moduleKey);
+    return String.format("Project with key '%s' not found on CodeScan server (was it deleted?)", moduleKey);
   }
 }

--- a/core/src/main/java/org/sonarsource/sonarlint/core/client/api/util/FileUtils.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/client/api/util/FileUtils.java
@@ -171,7 +171,7 @@ public class FileUtils {
         @Override
         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
           if (!isHidden(file)) {
-            retry(() -> paths.add(toSonarQubePath(dir.relativize(file).toString())));
+            retry(() -> paths.add(toCodeScanPath(dir.relativize(file).toString())));
           }
           return FileVisitResult.CONTINUE;
         }
@@ -210,12 +210,12 @@ public class FileUtils {
   }
 
   /**
-   * Converts path to format used by SonarQube
+   * Converts path to format used by CodeScan
    *
    * @param path path string in the local OS
-   * @return SonarQube path
+   * @return CodeScan path
    */
-  public static String toSonarQubePath(String path) {
+  public static String toCodeScanPath(String path) {
     if (File.separatorChar != '/') {
       return path.replaceAll(PATH_SEPARATOR_PATTERN, "/");
     }

--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/DefaultFilePredicates.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/DefaultFilePredicates.java
@@ -64,7 +64,7 @@ public class DefaultFilePredicates implements FilePredicates {
    */
   @Override
   public FilePredicate hasRelativePath(String s) {
-    throw new UnsupportedOperationException("hasRelativePath");
+    return new RelativePathPredicate(s);
   }
 
   @Override
@@ -104,7 +104,8 @@ public class DefaultFilePredicates implements FilePredicates {
 
   @Override
   public FilePredicate hasPath(String s) {
-    throw new UnsupportedOperationException("hasPath");
+    File file = new File(s);
+    return file.isAbsolute() ? this.hasAbsolutePath(s) : this.hasRelativePath(s);
   }
 
   @Override

--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/InputFileCache.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/InputFileCache.java
@@ -35,6 +35,7 @@ public class InputFileCache implements FileSystem.Index {
   private final Set<InputFile> inputFileCache = new LinkedHashSet<>();
   private final SetMultimap<String, InputFile> filesByNameCache = LinkedHashMultimap.create();
   private final SetMultimap<String, InputFile> filesByExtensionCache = LinkedHashMultimap.create();
+  private final SetMultimap<String, InputFile> filesByRelativePathCache = LinkedHashMultimap.create();
   private final SortedSet<String> languages = new TreeSet<>();
 
   @Override
@@ -49,11 +50,12 @@ public class InputFileCache implements FileSystem.Index {
     inputFileCache.add(inputFile);
     filesByNameCache.put(inputFile.filename(), inputFile);
     filesByExtensionCache.put(FileExtensionPredicate.getExtension(inputFile), inputFile);
+    filesByRelativePathCache.put(inputFile.relativePath(), inputFile);
   }
 
   @Override
   public InputFile inputFile(String relativePath) {
-    throw new UnsupportedOperationException("inputFile(String relativePath)");
+    return filesByRelativePathCache.get(relativePath).stream().findFirst().orElse(null);
   }
 
   @Override

--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/RelativePathPredicate.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/RelativePathPredicate.java
@@ -1,0 +1,69 @@
+/*
+ * SonarLint Core - Implementation
+ * Copyright (C) 2016-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.container.analysis.filesystem;
+
+import java.util.Collections;
+import javax.annotation.Nullable;
+import org.sonar.api.batch.fs.FileSystem.Index;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.utils.PathUtils;
+
+/**
+ * @since 4.2
+ */
+public class RelativePathPredicate extends AbstractFilePredicate {
+
+    @Nullable
+    private final String path;
+
+    RelativePathPredicate(String path) {
+        this.path = PathUtils.sanitize(path);
+    }
+
+    public String path() {
+        return path;
+    }
+
+    @Override
+    public boolean apply(InputFile f) {
+        if (path == null) {
+            return false;
+        }
+
+        return path.equals(f.relativePath());
+    }
+
+    @Override
+    public Iterable<InputFile> get(Index index) {
+        if (path != null) {
+            InputFile f = index.inputFile(this.path);
+            if (f != null) {
+                return Collections.singletonList(f);
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public int priority() {
+        return USE_INDEX;
+    }
+
+}

--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/connected/IssueStore.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/connected/IssueStore.java
@@ -36,7 +36,7 @@ public interface IssueStore {
   /**
    * Load issues stored for specified file.
    *
-   * @param sqFilePath the relative path to the base of project, in SonarQube
+   * @param sqFilePath the relative path to the base of project, in CodeScan
    * @return issues, possibly empty
    */
   List<ServerIssue> load(String sqFilePath);
@@ -44,7 +44,7 @@ public interface IssueStore {
   /**
    * Deletes issues stored for specified file, if they exist.
    *
-   * @param sqFilePath the relative path to the base of project, in SonarQube
+   * @param sqFilePath the relative path to the base of project, in CodeScan
    */
   void delete(String sqFilePath);
 }

--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/connected/update/ModuleHierarchyDownloader.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/connected/update/ModuleHierarchyDownloader.java
@@ -35,7 +35,7 @@ import org.sonarsource.sonarlint.core.serverapi.ServerApiHelper;
 import org.sonarsource.sonarlint.core.util.ProgressWrapper;
 import org.sonarsource.sonarlint.core.util.StringUtils;
 
-import static org.sonarsource.sonarlint.core.client.api.util.FileUtils.toSonarQubePath;
+import static org.sonarsource.sonarlint.core.client.api.util.FileUtils.toCodeScanPath;
 
 public class ModuleHierarchyDownloader {
   static final int PAGE_SIZE = 500;
@@ -89,7 +89,7 @@ public class ModuleHierarchyDownloader {
       c = ancestors.get(c);
     } while (c != null);
 
-    return toSonarQubePath(path.toString());
+    return toCodeScanPath(path.toString());
   }
 
   @CheckForNull

--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/connected/update/perform/ProjectStorageUpdateExecutor.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/connected/update/perform/ProjectStorageUpdateExecutor.java
@@ -72,7 +72,7 @@ public class ProjectStorageUpdateExecutor {
       if (!qProfileKeys.contains(qpKey)) {
         throw new IllegalStateException(
           "Project '" + projectKey + "' is associated to quality profile '" + qpKey + "' that is not in the storage. "
-            + "The SonarQube server binding is probably outdated,  please update it.");
+            + "The CodeScan server binding is probably outdated,  please update it.");
       }
     }
     ProtobufUtil.writeToFile(projectConfiguration, temp.resolve(ProjectStoragePaths.PROJECT_CONFIGURATION_PB));

--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/connected/validate/ServerVersionAndStatusChecker.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/connected/validate/ServerVersionAndStatusChecker.java
@@ -53,7 +53,7 @@ public class ServerVersionAndStatusChecker {
   }
 
   /**
-   * Checks SonarQube version against the minimum version supported by the library
+   * Checks CodeScan version against the minimum version supported by the library
    * @return ServerInfos
    * @throws UnsupportedServerException if version &lt; minimum supported version
    * @throws IllegalStateException If server is not ready
@@ -63,7 +63,7 @@ public class ServerVersionAndStatusChecker {
   }
 
   /**
-   * Checks SonarQube version against a provided minimum version
+   * Checks CodeScan version against a provided minimum version
    * @return ServerInfos
    * @throws UnsupportedServerException if version &lt; minimum supported version
    * @throws IllegalStateException If server is not ready
@@ -83,7 +83,7 @@ public class ServerVersionAndStatusChecker {
   }
 
   private static String unsupportedVersion(ServerInfos serverStatus, String minVersion) {
-    return "SonarQube server has version " + serverStatus.getVersion() + ". Version should be greater or equal to " + minVersion;
+    return "CodeScan server has version " + serverStatus.getVersion() + ". Version should be greater or equal to " + minVersion;
   }
 
   private static String serverNotReady(ServerInfos serverStatus) {

--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/global/SonarLintRuntimeImpl.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/global/SonarLintRuntimeImpl.java
@@ -56,12 +56,12 @@ public class SonarLintRuntimeImpl implements SonarLintRuntime {
 
   @Override
   public SonarQubeSide getSonarQubeSide() {
-    throw new UnsupportedOperationException("Can only be called in SonarQube");
+    throw new UnsupportedOperationException("Can only be called in CodeScan");
   }
 
   @Override
   public SonarEdition getEdition() {
-    throw new UnsupportedOperationException("Can only be called in SonarQube");
+    throw new UnsupportedOperationException("Can only be called in CodeScan");
   }
 
   @Override

--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/storage/SonarQubeActiveRulesProvider.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/storage/SonarQubeActiveRulesProvider.java
@@ -101,7 +101,7 @@ public class SonarQubeActiveRulesProvider extends ProviderAdapter {
     try {
       storageRule = storageRules.getRulesByKeyOrThrow(ruleKey.toString());
     } catch (IllegalArgumentException e) {
-      throw new StorageException("Unknown active rule in the quality profile of the project. Please update the SonarQube server binding.", e);
+      throw new StorageException("Unknown active rule in the quality profile of the project. Please update the CodeScan server binding.", e);
     }
 
     return new StorageActiveRuleAdapter(activeRule, storageRule);

--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/storage/StorageFileExclusions.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/storage/StorageFileExclusions.java
@@ -60,7 +60,7 @@ public class StorageFileExclusions {
       }
       String sqPath = issueStorePaths.idePathToSqPath(projectBinding, idePath);
       if (sqPath == null) {
-        // we can't map it to a SonarQube path, so just apply exclusions to the original ide path
+        // we can't map it to a CodeScan path, so just apply exclusions to the original ide path
         sqPath = idePath;
       }
       Type type = testFilePredicate.test(file) ? Type.TEST : Type.MAIN;

--- a/core/src/main/java/org/sonarsource/sonarlint/core/notifications/NotificationChecker.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/notifications/NotificationChecker.java
@@ -115,7 +115,7 @@ class NotificationChecker {
       }
 
     } catch (Exception e) {
-      LOG.error("Failed to parse SonarQube notifications response", e);
+      LOG.error("Failed to parse CodeScan notifications response", e);
       return Collections.emptyList();
     }
     return notifications;

--- a/core/src/main/java/org/sonarsource/sonarlint/core/plugin/PluginClassloaderFactory.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/plugin/PluginClassloaderFactory.java
@@ -113,7 +113,7 @@ public class PluginClassloaderFactory {
   }
 
   /**
-   * The resources (packages) that API exposes to plugins. Other core classes (SonarQube, MyBatis, ...)
+   * The resources (packages) that API exposes to plugins. Other core classes (CodeScan, MyBatis, ...)
    * can't be accessed.
    * <p>To sum-up, these are the classes packaged in sonar-plugin-api.jar or available as
    * a transitive dependency of sonar-plugin-api</p>

--- a/core/src/main/java/org/sonarsource/sonarlint/core/plugin/PluginInfo.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/plugin/PluginInfo.java
@@ -295,7 +295,7 @@ public class PluginInfo implements Comparable<PluginInfo> {
   }
 
   /**
-   * Find out if this plugin is compatible with a given version of SonarQube.
+   * Find out if this plugin is compatible with a given version of CodeScan.
    * The version of SQ must be greater than or equal to the minimal version
    * needed by the plugin.
    */

--- a/core/src/main/java/org/sonarsource/sonarlint/core/plugin/PluginInfosLoader.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/plugin/PluginInfosLoader.java
@@ -149,7 +149,7 @@ public class PluginInfosLoader {
       }
       if (Language.JS.getPluginKey().equals(info.getKey()) && OLD_SONARTS_PLUGIN_KEY.equals(required.getKey())) {
         // Workaround for SLCORE-259
-        // This dependency was added to ease migration on SonarQube, but can be ignored on SonarLint
+        // This dependency was added to ease migration on CodeScan, but can be ignored on SonarLint
         // Note: The dependency was removed in SonarJS 6.3 but we should still keep the workaround as long as we want to support older
         // versions
         continue;

--- a/core/src/main/java/org/sonarsource/sonarlint/core/serverapi/rules/RulesApi.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/serverapi/rules/RulesApi.java
@@ -78,7 +78,7 @@ public class RulesApi {
       Rules.SearchResponse response = loadFromStream(helper.get(getUrl(severity, enabledLanguages, page, pageSize)));
       if (response.getTotal() > 10_000) {
         throw new IllegalStateException(
-          String.format("Found more than 10000 rules for severity '%s' in the SonarQube server, which is not supported by SonarLint.", severity));
+          String.format("Found more than 10000 rules for severity '%s' in the CodeScan server, which is not supported by SonarLint.", severity));
       }
       readPage(rulesBuilder, activeRulesBuildersByQProfile, response);
       loaded += response.getPs();

--- a/core/src/main/resources/plugins_min_versions.txt
+++ b/core/src/main/resources/plugins_min_versions.txt
@@ -1,4 +1,4 @@
-# Minimum supported analyzer versions: the first versions supported by SonarQube 7.9,
+# Minimum supported analyzer versions: the first versions supported by CodeScan 7.9,
 # as defined in https://github.com/SonarSource/sonar-update-center-properties
 abap=3.8.0.2034
 cobol=4.4.0.3403
@@ -19,3 +19,6 @@ tsql=1.4.0.3334
 typescript=1.9.0.3766
 web=3.1.0.1615
 xml=2.0.1.2020
+salesforce=4.3
+codescan=4.3
+codescanlang=4.3

--- a/core/src/test/java/org/sonarsource/sonarlint/core/client/api/connected/ConnectionValidatorTests.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/client/api/connected/ConnectionValidatorTests.java
@@ -97,7 +97,7 @@ class ConnectionValidatorTests {
 
     ValidationResult validation = futureValidation.get();
     assertThat(validation.success()).isFalse();
-    assertThat(validation.message()).isEqualTo("SonarQube server has version 6.7. Version should be greater or equal to 7.9");
+    assertThat(validation.message()).isEqualTo("CodeScan server has version 6.7. Version should be greater or equal to 7.9");
   }
 
   @Test

--- a/core/src/test/java/org/sonarsource/sonarlint/core/client/api/exceptions/ProjectNotFoundExceptionTests.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/client/api/exceptions/ProjectNotFoundExceptionTests.java
@@ -28,12 +28,12 @@ class ProjectNotFoundExceptionTests {
   @Test
   void show_organization_key() {
     ProjectNotFoundException ex = new ProjectNotFoundException("module", "organization");
-    assertThat(ex.getMessage()).isEqualTo("Project with key 'module' in organization 'organization' not found on SonarQube server (was it deleted?)");
+    assertThat(ex.getMessage()).isEqualTo("Project with key 'module' in organization 'organization' not found on CodeScan server (was it deleted?)");
   }
 
   @Test
   void organization_key_missing() {
     ProjectNotFoundException ex = new ProjectNotFoundException("module", null);
-    assertThat(ex.getMessage()).isEqualTo("Project with key 'module' not found on SonarQube server (was it deleted?)");
+    assertThat(ex.getMessage()).isEqualTo("Project with key 'module' not found on CodeScan server (was it deleted?)");
   }
 }

--- a/core/src/test/java/org/sonarsource/sonarlint/core/client/api/util/FileUtilsTests.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/client/api/util/FileUtilsTests.java
@@ -186,9 +186,9 @@ class FileUtilsTests {
   }
 
   @Test
-  void toSonarQubePath_should_return_slash_separated_path() {
+  void toCodeScanPath_should_return_slash_separated_path() {
     Path path = Paths.get("some").resolve("relative").resolve("path");
-    assertThat(FileUtils.toSonarQubePath(path.toString())).isEqualTo("some/relative/path");
+    assertThat(FileUtils.toCodeScanPath(path.toString())).isEqualTo("some/relative/path");
   }
 
   @Test

--- a/core/src/test/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/DefaultFilePredicatesTests.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/DefaultFilePredicatesTests.java
@@ -101,7 +101,7 @@ class DefaultFilePredicatesTests {
 
   @Test
   public void has_relative_path_unsupported() {
-    assertThrows(UnsupportedOperationException.class, () -> predicates.hasRelativePath("src/main/java/struts/Action.java").apply(javaFile));
+    assertThat(predicates.hasRelativePath("src/main/java/struts/Action.java").apply(javaFile)).isTrue();
   }
 
   @Test
@@ -133,7 +133,7 @@ class DefaultFilePredicatesTests {
 
   @Test
   public void has_path() throws Exception {
-    assertThrows(UnsupportedOperationException.class, () -> predicates.hasPath("src/main/java/struts/Action.java").apply(javaFile));
+    assertThat(predicates.hasPath("src/main/java/struts/Action.java").apply(javaFile)).isTrue();
   }
 
   @Test

--- a/core/src/test/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/InputFileBuilderTest.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/InputFileBuilderTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-import static org.sonarsource.sonarlint.core.client.api.util.FileUtils.toSonarQubePath;
+import static org.sonarsource.sonarlint.core.client.api.util.FileUtils.toCodeScanPath;
 
 public class InputFileBuilderTest {
   @Rule
@@ -65,7 +65,7 @@ public class InputFileBuilderTest {
 
     assertThat(inputFile.type()).isEqualTo(InputFile.Type.TEST);
     assertThat(inputFile.file()).isEqualTo(path.toFile());
-    assertThat(inputFile.absolutePath()).isEqualTo(toSonarQubePath(path.toString()));
+    assertThat(inputFile.absolutePath()).isEqualTo(toCodeScanPath(path.toString()));
     assertThat(inputFile.language()).isEqualTo("java");
     assertThat(inputFile.key()).isEqualTo(path.toUri().toString());
     assertThat(inputFile.lines()).isEqualTo(1);

--- a/core/src/test/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/InputFileCacheTests.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/InputFileCacheTests.java
@@ -49,8 +49,6 @@ class InputFileCacheTests {
     cache.doAdd(file2);
     assertThat(cache.inputFiles()).containsOnly(file1, file2);
 
-    assertThrows(UnsupportedOperationException.class, () -> cache.inputFile("file1.java"));
-
     assertThat(cache.getFilesByExtension("java")).containsOnly(file1);
     assertThat(cache.getFilesByExtension("")).containsOnly(file2);
     assertThat(cache.getFilesByName("file1.java")).containsOnly(file1);

--- a/core/src/test/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/SonarLintInputFileTests.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/container/analysis/filesystem/SonarLintInputFileTests.java
@@ -38,7 +38,7 @@ import org.sonarsource.sonarlint.core.client.api.common.analysis.ClientInputFile
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.sonarsource.sonarlint.core.client.api.util.FileUtils.toSonarQubePath;
+import static org.sonarsource.sonarlint.core.client.api.util.FileUtils.toCodeScanPath;
 
 class SonarLintInputFileTests {
 
@@ -51,7 +51,7 @@ class SonarLintInputFileTests {
 
     assertThat(file.contents()).isEqualTo("test string");
     assertThat(file.charset()).isEqualByComparingTo(StandardCharsets.UTF_8);
-    assertThat(file.absolutePath()).isEqualTo(toSonarQubePath(inputFile.getPath()));
+    assertThat(file.absolutePath()).isEqualTo(toCodeScanPath(inputFile.getPath()));
     assertThat(file.file()).isEqualTo(filePath.toFile());
     assertThat(file.path()).isEqualTo(filePath);
     assertThat(file.getClientInputFile()).isEqualTo(inputFile);

--- a/core/src/test/java/org/sonarsource/sonarlint/core/container/connected/validate/ServerVersionAndStatusCheckerTests.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/container/connected/validate/ServerVersionAndStatusCheckerTests.java
@@ -69,7 +69,7 @@ class ServerVersionAndStatusCheckerTests {
 
     ValidationResult validationResult = futureResult.get();
     assertThat(validationResult.success()).isFalse();
-    assertThat(validationResult.message()).isEqualTo("SonarQube server has version 6.7. Version should be greater or equal to 7.9");
+    assertThat(validationResult.message()).isEqualTo("CodeScan server has version 6.7. Version should be greater or equal to 7.9");
   }
 
   @Test
@@ -78,7 +78,7 @@ class ServerVersionAndStatusCheckerTests {
 
     Throwable throwable = catchThrowable(() -> underTest.checkVersionAndStatus());
 
-    assertThat(throwable).hasMessage("SonarQube server has version 6.7. Version should be greater or equal to 7.9");
+    assertThat(throwable).hasMessage("CodeScan server has version 6.7. Version should be greater or equal to 7.9");
   }
 
   @Test

--- a/core/src/test/java/org/sonarsource/sonarlint/core/container/module/ModuleInputFileBuilderTest.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/container/module/ModuleInputFileBuilderTest.java
@@ -41,7 +41,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-import static org.sonarsource.sonarlint.core.client.api.util.FileUtils.toSonarQubePath;
+import static org.sonarsource.sonarlint.core.client.api.util.FileUtils.toCodeScanPath;
 
 public class ModuleInputFileBuilderTest {
   @Rule
@@ -65,7 +65,7 @@ public class ModuleInputFileBuilderTest {
 
     assertThat(inputFile.type()).isEqualTo(InputFile.Type.TEST);
     assertThat(inputFile.file()).isEqualTo(path.toFile());
-    assertThat(inputFile.absolutePath()).isEqualTo(toSonarQubePath(path.toString()));
+    assertThat(inputFile.absolutePath()).isEqualTo(toCodeScanPath(path.toString()));
     assertThat(inputFile.language()).isEqualTo("java");
     assertThat(inputFile.key()).isEqualTo(path.toUri().toString());
     assertThat(inputFile.lines()).isEqualTo(1);

--- a/core/src/test/java/org/sonarsource/sonarlint/core/serverapi/rules/RulesApiTest.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/serverapi/rules/RulesApiTest.java
@@ -57,7 +57,7 @@ class RulesApiTest {
     RulesApi rulesApi = new RulesApi(mockServer.serverApiHelper());
 
     IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> rulesApi.getAll(enabledLanguages, progressWrapper));
-    assertThat(thrown).hasMessage("Found more than 10000 rules for severity 'MAJOR' in the SonarQube server, which is not supported by SonarLint.");
+    assertThat(thrown).hasMessage("Found more than 10000 rules for severity 'MAJOR' in the CodeScan server, which is not supported by SonarLint.");
   }
 
   @Test

--- a/its/plugins/custom-sensor-plugin/pom.xml
+++ b/its/plugins/custom-sensor-plugin/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <groupId>org.sonarsource.sonarlint.core</groupId>
     <artifactId>sonarlint-core-its</artifactId>
-    <version>7.0-SNAPSHOT</version>
+    <version>7.0.0-CODESCAN</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   
   <groupId>org.sonarsource.plugins.example</groupId>
   <artifactId>custom-sensor-plugin</artifactId>
   <packaging>sonar-plugin</packaging>
-  <version>7.0-SNAPSHOT</version>
+  <version>7.0.0-CODESCAN</version>
 
-  <name>Example Plugin for SonarQube</name>
-  <description>Example of plugin for SonarQube</description>
+  <name>Example Plugin for CodeScan</name>
+  <description>Example of plugin for CodeScan</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/its/plugins/custom-sensor-plugin/src/main/java/org/sonarsource/plugins/example/ExamplePlugin.java
+++ b/its/plugins/custom-sensor-plugin/src/main/java/org/sonarsource/plugins/example/ExamplePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Example Plugin for SonarQube
+ * Example Plugin for CodeScan
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/its/plugins/custom-sensor-plugin/src/main/java/org/sonarsource/plugins/example/FooLintRulesDefinition.java
+++ b/its/plugins/custom-sensor-plugin/src/main/java/org/sonarsource/plugins/example/FooLintRulesDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Example Plugin for SonarQube
+ * Example Plugin for CodeScan
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/its/plugins/custom-sensor-plugin/src/main/java/org/sonarsource/plugins/example/OneIssuePerLineSensor.java
+++ b/its/plugins/custom-sensor-plugin/src/main/java/org/sonarsource/plugins/example/OneIssuePerLineSensor.java
@@ -1,5 +1,5 @@
 /*
- * Example Plugin for SonarQube
+ * Example Plugin for CodeScan
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *

--- a/its/plugins/global-extension-plugin/pom.xml
+++ b/its/plugins/global-extension-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.sonarlint.core</groupId>
     <artifactId>sonarlint-core-its</artifactId>
-    <version>7.0-SNAPSHOT</version>
+    <version>7.0.0-CODESCAN</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   

--- a/its/plugins/java-custom-rules/pom.xml
+++ b/its/plugins/java-custom-rules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.sonarlint.core</groupId>
     <artifactId>sonarlint-core-its</artifactId>
-    <version>7.0-SNAPSHOT</version>
+    <version>7.0.0-CODESCAN</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.sonarsource.sonarlint.core</groupId>
     <artifactId>sonarlint-core-parent</artifactId>
-    <version>7.0-SNAPSHOT</version>
+    <version>7.0.0-CODESCAN</version>
   </parent>
   <artifactId>sonarlint-core-its</artifactId>
   <name>SonarLint Core - ITs</name>

--- a/its/tests/pom.xml
+++ b/its/tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.sonarsource.sonarlint.core</groupId>
     <artifactId>sonarlint-core-its</artifactId>
-    <version>7.0-SNAPSHOT</version>
+    <version>7.0.0-CODESCAN</version>
   </parent>
   <artifactId>sonarlint-core-its-tests</artifactId>
   <name>SonarLint Core - ITs - Tests</name>

--- a/language-server/src/main/java/org/sonarlint/languageserver/ChromeNativeMessaging.java
+++ b/language-server/src/main/java/org/sonarlint/languageserver/ChromeNativeMessaging.java
@@ -1,0 +1,179 @@
+/*
+ * SonarLint Language Server
+ * Copyright (C) 2009-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.languageserver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class ChromeNativeMessaging {
+
+    public static class Out extends OutputStream {
+        private final StringBuilder header = new StringBuilder();
+        private int contentRemaining = -1;
+        private final OutputStream out;
+
+        public Out() {
+            this.out = System.out;
+            //redirect stdout to stderr
+            System.setOut(System.err);
+        }
+        public Out(OutputStream out) {
+            this.out = out;
+        }
+
+        private int isHeaderEnd() throws IOException {
+            if ( header.length() < 5 )
+                return -1;
+
+            int from = header.length()-4;
+            int to = header.length();
+            char c;
+            for ( int i=from;i<to;i++) {
+                c = header.charAt(i);
+                if ( c != '\r' && c != '\n')
+                    return -1;
+            }
+
+//      System.err.println("Headers: " + header);
+            for ( String line : header.toString().split("\r\n") ) {
+                if ( line.startsWith("Content-Length: ") ) {
+                    int contentLength = Integer.parseInt(line.substring("Content-Length: ".length()));
+                    byte[] byte4 = ByteBuffer.allocate(4).order(ByteOrder.nativeOrder()).putInt(contentLength).array();
+//          System.err.println("write=" + byte4[0]);
+//          System.err.println("write=" + byte4[1]);
+//          System.err.println("write=" + byte4[2]);
+//          System.err.println("write=" + byte4[3]);
+//          System.err.println("write contentLength=" + contentLength);
+                    out.write(byte4);
+                    header.setLength(0);
+                    return contentLength;
+                }
+            }
+
+            header.setLength(0);
+            return 0;
+        }
+
+        public void write(ByteBuffer r, ByteBuffer w) throws IOException {
+            while ( r.remaining() > 0 ) {
+                if ( contentRemaining <= 0 ) {
+                    header.append((char)r.get());
+                    contentRemaining = isHeaderEnd();
+                }else {
+                    byte next = r.get();
+//          System.err.println("w: " + (char)next + " remaining: " + contentRemaining);
+                    w.put(next);
+                    contentRemaining--;
+                }
+            }
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            ByteBuffer r = ByteBuffer.wrap(new byte[] {(byte)b});
+            ByteBuffer w = ByteBuffer.allocate(1);
+            write(r, w);
+            int l = w.position();
+            if ( l > 0 ) {
+                w.rewind();
+                out.write(w.get());
+            }
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            ByteBuffer r = ByteBuffer.wrap(b, off, len);
+            ByteBuffer w = ByteBuffer.allocate(len);
+            write(r, w);
+            int l = w.position();
+            if ( l > 0 ) {
+                w.rewind();
+                out.write(w.array(), off, l);
+            }
+        }
+    }
+
+    public static class In extends InputStream{
+        private final InputStream in;
+        private ByteBuffer header = null;
+        private int contentRemaining = -1;
+
+        public In() {
+            this.in = System.in;
+        }
+        public In(InputStream out) {
+            this.in = out;
+        }
+
+        public void read(ByteBuffer ret) throws IOException {
+            while ( ret.remaining() > 0 ) {
+                if ( header != null ) {
+                    int next = header.get();
+                    if ( header.remaining() == 0 )
+                        header = null;
+                    ret.put((byte)next);
+                }else if ( contentRemaining <= 0 ){
+                    ByteBuffer len = ByteBuffer.allocate(4).order(ByteOrder.nativeOrder());
+                    int read = in.read(len.array());
+                    if ( read != 4 )
+                        break;
+                    contentRemaining = len.getInt();
+
+                    len.rewind();
+//          System.err.println("read=" + len.get());
+//          System.err.println("read=" + len.get());
+//          System.err.println("read=" + len.get());
+//          System.err.println("read=" + len.get());
+
+                    len.rewind();
+                    header = ByteBuffer.wrap(("Content-Length: " + contentRemaining + "\r\n\r\n").getBytes());
+//          System.err.println("read=" + new String(header.array()));
+                    ret.put(header.get());
+                }else {
+                    contentRemaining--;
+                    int next = in.read();
+//          System.err.println("r: " + (char)next + " remaining: " + contentRemaining);
+                    ret.put((byte)next);
+                }
+            }
+        }
+
+        @Override
+        public int read() throws IOException {
+            ByteBuffer r = ByteBuffer.allocate(1);
+            read(r);
+            r.rewind();
+            return r.get();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            ByteBuffer r = ByteBuffer.wrap(b, off, len);
+            read(r);
+            if ( r.position() == 0 )
+                return -1;
+            return r.position();
+        }
+
+    }
+}

--- a/language-server/src/test/java/org/sonarlint/languageserver/ChromeNativeMessagingTest.java
+++ b/language-server/src/test/java/org/sonarlint/languageserver/ChromeNativeMessagingTest.java
@@ -1,0 +1,71 @@
+/*
+ * SonarLint Language Server
+ * Copyright (C) 2009-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.languageserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+public class ChromeNativeMessagingTest {
+
+    @Test
+    public void testOut() throws Exception {
+        ByteArrayOutputStream res = new ByteArrayOutputStream();
+        try(ChromeNativeMessaging.Out out = new ChromeNativeMessaging.Out(res)){
+            StringBuilder outData = new StringBuilder();
+            outData.append("Content-Length: 10\r\n\r\n");
+            outData.append("0123456789");
+            out.write(outData.toString().getBytes());
+            assertThat(res.toByteArray().length).isEqualTo(14);
+            assertThat(res.toByteArray()[4]).isEqualTo((byte)'0');
+            assertThat(res.toByteArray()[13]).isEqualTo((byte)'9');
+
+            //try continuing
+            outData = new StringBuilder();
+            outData.append("Content-Length: 5\r\n\r\n");
+            outData.append("01234");
+            out.write(outData.toString().getBytes());
+            assertThat(res.toByteArray().length).isEqualTo(23);
+            assertThat(res.toByteArray()[18]).isEqualTo((byte)'0');
+            assertThat(res.toByteArray()[22]).isEqualTo((byte)'4');
+        }
+    }
+
+    @Test
+    public void testIn() throws Exception {
+        ByteArrayOutputStream inData = new ByteArrayOutputStream();
+        inData.write(ByteBuffer.allocate(4).order(ByteOrder.nativeOrder()).putInt(10).array());
+        inData.write("0123456789".getBytes());
+        inData.write(ByteBuffer.allocate(4).order(ByteOrder.nativeOrder()).putInt(5).array());
+        inData.write("01234".getBytes());
+
+        ByteArrayOutputStream res = new ByteArrayOutputStream();
+        try(ChromeNativeMessaging.In in = new ChromeNativeMessaging.In(new ByteArrayInputStream(inData.toString().getBytes()))){
+            IOUtils.copy(in, res);
+            assertThat(new String(res.toByteArray())).isEqualTo("Content-Length: 10\r\n\r\n0123456789Content-Length: 5\r\n\r\n01234");
+        }
+    }
+}

--- a/plugin-api/pom.xml
+++ b/plugin-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.sonarlint.core</groupId>
     <artifactId>sonarlint-core-parent</artifactId>
-    <version>7.0-SNAPSHOT</version>
+    <version>7.0.0-CODESCAN</version>
   </parent>
   <artifactId>sonarlint-plugin-api</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.sonarsource.sonarlint.core</groupId>
   <artifactId>sonarlint-core-parent</artifactId>
-  <version>7.0-SNAPSHOT</version>
+  <version>7.0.0-CODESCAN</version>
   <packaging>pom</packaging>
   <name>SonarLint Core</name>
   <description>Library used by SonarLint flavors (Eclipse, IntelliJ, VSCode...)</description>

--- a/scripts/generate-plugins-min-versions.sh
+++ b/scripts/generate-plugins-min-versions.sh
@@ -38,7 +38,7 @@ get_min_plugin_version() {
 }
 
 print_plugins_min_versions() {
-    echo "# Minimum supported analyzer versions: the first versions supported by SonarQube $version,"
+    echo "# Minimum supported analyzer versions: the first versions supported by CodeScan $version,"
     echo "# as defined in $update_center_repo"
     for plugin in "${plugins[@]}"; do
         echo "$plugin=${minVersions[$plugin]}"

--- a/slf4j-sonar-log/pom.xml
+++ b/slf4j-sonar-log/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.sonarsource.sonarlint.core</groupId>
     <artifactId>sonarlint-core-parent</artifactId>
-    <version>7.0-SNAPSHOT</version>
+    <version>7.0.0-CODESCAN</version>
   </parent>
   <artifactId>sonarlint-slf4j-sonar-log</artifactId>
   <name>SonarLint slf4j log adaptor</name>


### PR DESCRIPTION
The file extension logic is removed from `core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryUtils.java` in latest version of sonarlint-core. 
It is now added to `core/src/main/java/org/sonarsource/sonarlint/core/client/api/common/Language.java`
So the changes for this commit is added differently in latest version: 
https://github.com/VillageChief/sonarlint-core/commit/8589d6c14d4b3411b29029660b8021ceb61af07d